### PR TITLE
do not add project to OP time entry if empty

### DIFF
--- a/openproject/timeentry.go
+++ b/openproject/timeentry.go
@@ -27,9 +27,9 @@ type TimeEntry struct {
 			Title string `json:"title"`
 		} `json:"activity"`
 		Project struct {
-			Href  string `json:"href"`
-			Title string `json:"title"`
-		} `json:"project"`
+			Href  string `json:"href,omitempty"`
+			Title string `json:"title,omitempty"`
+		} `json:"project,omitempty"`
 	} `json:"_links"`
 }
 


### PR DESCRIPTION
during the copy process we do not set a project to the OP time-entry as it's not needed to create a time-entry in OP.
But leaving it empty gives a 422 error.
This small change will omit the whole property while marshaling into JSON if its empty