### PR TITLE
sort timeentries better

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/term"
 	"os"
 	"path"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -96,9 +95,6 @@ var diffCmd = &cobra.Command{
 			_, _ = fmt.Fprint(os.Stderr, err)
 			os.Exit(1)
 		}
-		sort.Slice(tmetricTimeEntries, func(i, j int) bool {
-			return tmetricTimeEntries[i].Note < tmetricTimeEntries[j].Note
-		})
 
 		var openProjectUser openproject.User
 		if userNameFromCmd != "" {
@@ -115,9 +111,6 @@ var diffCmd = &cobra.Command{
 			_, _ = fmt.Fprint(os.Stderr, err)
 			os.Exit(1)
 		}
-		sort.Slice(openProjectTimeEntries, func(i, j int) bool {
-			return openProjectTimeEntries[i].Comment.Raw < openProjectTimeEntries[j].Comment.Raw
-		})
 
 		start, _ := time.Parse("2006-01-02", startDate)
 		end, _ := time.Parse("2006-01-02", endDate)

--- a/openproject/openproject.go
+++ b/openproject/openproject.go
@@ -42,7 +42,7 @@ func GetAllTimeEntries(config *config.Config, user User, startDate string, endDa
 		SetBasicAuth("apikey", config.OpenProjectToken).
 		SetHeader("Content-Type", "application/json").
 		SetQueryParam("pageSize", "3000").
-		SetQueryParam("sortBy", "[[\"updated_at\",\"desc\"]]").
+		SetQueryParam("sortBy", "[[\"updated_at\",\"asc\"]]").
 		// the operator is '<>d' and means between the dates
 		SetQueryParam("filters", fmt.Sprintf(
 			`[{"user":{"operator":"=","values":["%v"]}},{"spent_on":{"operator":"\u003c\u003ed","values":["%v","%v"]}}]`,

--- a/tmetric/tmetric.go
+++ b/tmetric/tmetric.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/JankariTech/OpenProjectTmetricIntegration/config"
 	"github.com/go-resty/resty/v2"
+	"sort"
 )
 
 func GetAllTimeEntries(config *config.Config, tmetricUser User, startDate string, endDate string) ([]TimeEntry, error) {
@@ -39,6 +40,10 @@ func GetAllTimeEntries(config *config.Config, tmetricUser User, startDate string
 			timeEntriesOfTheSelectedClient = append(timeEntriesOfTheSelectedClient, entry)
 		}
 	}
+	sort.Slice(timeEntriesOfTheSelectedClient, func(i, j int) bool {
+		return timeEntriesOfTheSelectedClient[i].StartTime < timeEntriesOfTheSelectedClient[j].StartTime
+	})
+
 	return timeEntriesOfTheSelectedClient, nil
 }
 


### PR DESCRIPTION
1. sort the tmetric time entries by start date (using the sort function)
2. sort the OpenProject time entries ascending by update date

This has two benefits:
1. when running the check, the time entries will come up in the correct order
2. future diffs will show entries in the correct order. Because they will be copied over to OpenProject in the order of the start-date in tmetric, the update date in OpenProject will follow the same order