### PR TITLE
allow filtering timeentries by workpackage ids

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -107,7 +107,7 @@ var diffCmd = &cobra.Command{
 			}
 		}
 
-		openProjectTimeEntries, err := openproject.GetAllTimeEntries(config, openProjectUser, startDate, endDate)
+		openProjectTimeEntries, err := openproject.GetAllTimeEntries(config, openProjectUser, startDate, endDate, nil)
 		if err != nil {
 			_, _ = fmt.Fprint(os.Stderr, err)
 			os.Exit(1)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -89,14 +89,14 @@ var exportCmd = &cobra.Command{
 				startTime, _ := time.Parse("2006-01-02", startDate)
 				return startTime.Format("01/2006")
 			},
-			"AllTimeEntriesFromOpenProject": func(user string) []openproject.TimeEntry {
+			"AllTimeEntriesFromOpenProject": func(user string, workpackages []any) []openproject.TimeEntry {
 				var openProjectUser openproject.User
 				openProjectUser, err := openproject.FindUserByName(config, user)
 				if err != nil {
 					_, _ = fmt.Fprint(os.Stderr, err)
 					os.Exit(1)
 				}
-				openProjectTimeEntries, err := openproject.GetAllTimeEntries(config, openProjectUser, startDate, endDate)
+				openProjectTimeEntries, err := openproject.GetAllTimeEntries(config, openProjectUser, startDate, endDate, workpackages)
 				if err != nil {
 					_, _ = fmt.Fprint(os.Stderr, err)
 					os.Exit(1)

--- a/tmetric/report.go
+++ b/tmetric/report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/JankariTech/OpenProjectTmetricIntegration/config"
@@ -12,9 +13,11 @@ import (
 )
 
 type ReportItem struct {
-	StartTime string `json:"startTime"`
-	EndTime   string `json:"endTime"`
-	User      string `json:"user"`
+	StartTime     string `json:"startTime"`
+	EndTime       string `json:"endTime"`
+	User          string `json:"user"`
+	IssueId       string `json:"issueId"`
+	WorkpackageId string
 }
 
 type Report struct {
@@ -118,6 +121,7 @@ func GetDetailedReport(
 	}
 	var report Report
 	for _, item := range reportItems {
+		item.WorkpackageId = strings.Trim(item.IssueId, "#") // remove leading '#' from issue id
 		report.ReportItems = append(report.ReportItems, item)
 		itemDuration, _ := item.getDuration()
 		report.Duration += itemDuration


### PR DESCRIPTION
This allows the template to filter the timeentries by workpackages.
It is useful when limiting the export to a particular tmetric project (#22). If in that case we also want to use `AllTimeEntriesFromOpenProject` in the template, only the entries should be shown that were returned by the tmertric report

In the template all workpackages can be collected while looping through the report items e.g. by `{{- $allWorkpackages = (append $allWorkpackages $reportItem.WorkpackageId | uniq) }}`

and then to generate the list of time entries from Openproject that list of workpackages can be given to `AllTimeEntriesFromOpenProject`
e.g. `{{- range $j,$timeEntry := AllTimeEntriesFromOpenProject $user $allWorkpackages }}`