### PR TITLE
allow to set date in the export

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -59,6 +59,9 @@ var exportCmd = &cobra.Command{
 			"ArbitraryString": func(i int) string {
 				return arbitraryString[i]
 			},
+			"ExportDate": func() string {
+				return exportDate
+			},
 			"DetailedReport": func(clientName string, tagName string, groupName string) tmetric.Report {
 				report, err := tmetric.GetDetailedReport(
 					config, tmetricUser, clientName, tagName, groupName, startDate, endDate, projects,
@@ -131,6 +134,9 @@ func init() {
 	exportCmd.Flags().StringVarP(&startDate, "start", "s", firstDayOfMonth, "start date")
 	today := time.Now().Format("2006-01-02")
 	exportCmd.Flags().StringVarP(&endDate, "end", "e", today, "end date")
+	exportCmd.Flags().StringVarP(
+		&exportDate, "date", "d", today, "date entry to be used in the export",
+	)
 	exportCmd.Flags().StringArrayVarP(
 		&arbitraryString,
 		"arbitraryString",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,9 +19,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/briandowns/spinner"
 	"os"
 	"time"
+
+	"github.com/briandowns/spinner"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -30,6 +31,7 @@ import (
 var cfgFile string
 var startDate string
 var endDate string
+var exportDate string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
this adds one more flag to the `export` command, with `-d` or `--date` a specific date can be set
That string can be accessed in the template with `ExportDate`
The flag is optional and will default to `now`

@phil-davis to use it in our current bill template you would have to set this line
`### Detmold {{ now | date "02.01.2006" }}`
to
`### Detmold {{ mustToDate "2006-01-02" ExportDate | date "02.01.2006" }}`