### PR TITLE
get more details for export

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -72,6 +72,9 @@ var exportCmd = &cobra.Command{
 				}
 				return report
 			},
+			"AllSelectedProjects": func() []string {
+				return projects
+			},
 			"AllWorkTypes": func() []tmetric.Tag {
 				workTypes, _ := tmetric.GetAllWorkTypes(config, tmetricUser)
 				return workTypes

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -57,7 +57,11 @@ var exportCmd = &cobra.Command{
 
 		funcMap := template.FuncMap{
 			"ArbitraryString": func(i int) string {
-				return arbitraryString[i]
+				if len(arbitraryString) >= i+1 {
+					return arbitraryString[i]
+				}
+
+				return ""
 			},
 			"ExportDate": func() string {
 				return exportDate

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -75,6 +75,23 @@ var exportCmd = &cobra.Command{
 			"AllSelectedProjects": func() []string {
 				return projects
 			},
+			"AllProjectsOfClient": func(clientName string) []string {
+				client, err := tmetric.GetClientByName(config, tmetricUser, clientName)
+				if err != nil {
+					_, _ = fmt.Fprint(os.Stderr, err)
+					os.Exit(1)
+				}
+				projects, err := tmetric.GetAllProjects(config, tmetricUser, client)
+				if err != nil {
+					_, _ = fmt.Fprint(os.Stderr, err)
+					os.Exit(1)
+				}
+				var projectNames []string
+				for _, project := range projects {
+					projectNames = append(projectNames, project.Name)
+				}
+				return projectNames
+			},
 			"AllWorkTypes": func() []tmetric.Tag {
 				workTypes, _ := tmetric.GetAllWorkTypes(config, tmetricUser)
 				return workTypes

--- a/tmetric/report.go
+++ b/tmetric/report.go
@@ -13,11 +13,15 @@ import (
 )
 
 type ReportItem struct {
-	StartTime     string `json:"startTime"`
-	EndTime       string `json:"endTime"`
-	User          string `json:"user"`
-	IssueId       string `json:"issueId"`
-	WorkpackageId string
+	StartTime          string `json:"startTime"`
+	EndTime            string `json:"endTime"`
+	User               string `json:"user"`
+	IssueId            string `json:"issueId"`
+	Project            string `json:"project"`
+	Client             string `json:"client"`
+	Description        string `json:"description"`
+	WorkpackageId      string
+	CalculatedDuration time.Duration
 }
 
 type Report struct {
@@ -122,9 +126,9 @@ func GetDetailedReport(
 	var report Report
 	for _, item := range reportItems {
 		item.WorkpackageId = strings.Trim(item.IssueId, "#") // remove leading '#' from issue id
+		item.CalculatedDuration, _ = item.getDuration()
 		report.ReportItems = append(report.ReportItems, item)
-		itemDuration, _ := item.getDuration()
-		report.Duration += itemDuration
+		report.Duration += item.CalculatedDuration
 	}
 	return report, nil
 }

--- a/tmetric/report.go
+++ b/tmetric/report.go
@@ -77,7 +77,7 @@ func GetDetailedReport(
 
 	var projectsIds []string // we need a slice of strings for the URL parameters, so let's declare it a string slice
 	for _, projectName := range projects {
-		project, err := getProjectByName(config, tmetricUser, projectName)
+		project, err := getProjectByName(config, tmetricUser, projectName, client)
 		if err != nil {
 			return Report{}, err
 		}

--- a/tmetric/report.go
+++ b/tmetric/report.go
@@ -65,7 +65,7 @@ func (reportItem *ReportItem) getDuration() (time.Duration, error) {
 func GetDetailedReport(
 	config *config.Config, tmetricUser User, clientName string, tagName string, groupName string, startDate string, endDate string, projects []string,
 ) (Report, error) {
-	client, err := getClientByName(config, tmetricUser, clientName)
+	client, err := GetClientByName(config, tmetricUser, clientName)
 	if err != nil {
 		return Report{}, err
 	}

--- a/tmetric/tmetric.go
+++ b/tmetric/tmetric.go
@@ -73,7 +73,7 @@ func getTeamByName(config *config.Config, tmetricUser User, name string) (Team, 
 	return Team{}, fmt.Errorf("could not find any team with name '%v'", name)
 }
 
-func getAllProjects(config *config.Config, tmetricUser User, client Client) ([]ProjectV2, error) {
+func GetAllProjects(config *config.Config, tmetricUser User, client Client) ([]ProjectV2, error) {
 	httpClient := resty.New()
 	tmetricUrl, _ := url.JoinPath(
 		config.TmetricAPIBaseUrl, "accounts/", strconv.Itoa(tmetricUser.ActiveAccountId), "/projects",
@@ -96,7 +96,7 @@ func getAllProjects(config *config.Config, tmetricUser User, client Client) ([]P
 }
 
 func getProjectByName(config *config.Config, tmetricUser User, name string, client Client) (ProjectV2, error) {
-	projects, err := getAllProjects(config, tmetricUser, client)
+	projects, err := GetAllProjects(config, tmetricUser, client)
 	if err != nil {
 		return ProjectV2{}, err
 	}
@@ -152,7 +152,7 @@ func getWorkTypeByName(config *config.Config, tmetricUser User, name string) (Ta
 	return Tag{}, fmt.Errorf("could not find any work type with name '%v'", name)
 }
 
-func getClientByName(config *config.Config, tmetricUser User, name string) (Client, error) {
+func GetClientByName(config *config.Config, tmetricUser User, name string) (Client, error) {
 	httpClient := resty.New()
 	tmetricUrl, _ := url.JoinPath(
 		config.TmetricAPIBaseUrl, "accounts/", strconv.Itoa(tmetricUser.ActiveAccountId), "/clients",

--- a/tmetric/tmetric.go
+++ b/tmetric/tmetric.go
@@ -73,12 +73,13 @@ func getTeamByName(config *config.Config, tmetricUser User, name string) (Team, 
 	return Team{}, fmt.Errorf("could not find any team with name '%v'", name)
 }
 
-func getAllProjects(config *config.Config, tmetricUser User) ([]ProjectV2, error) {
+func getAllProjects(config *config.Config, tmetricUser User, client Client) ([]ProjectV2, error) {
 	httpClient := resty.New()
 	tmetricUrl, _ := url.JoinPath(
 		config.TmetricAPIBaseUrl, "accounts/", strconv.Itoa(tmetricUser.ActiveAccountId), "/projects",
 	)
 	resp, err := httpClient.R().
+		SetQueryParam("ClientList", strconv.Itoa(client.Id)).
 		SetAuthToken(config.TmetricToken).
 		Get(tmetricUrl)
 	if err != nil || resp.StatusCode() != 200 {
@@ -94,8 +95,8 @@ func getAllProjects(config *config.Config, tmetricUser User) ([]ProjectV2, error
 	return projects, nil
 }
 
-func getProjectByName(config *config.Config, tmetricUser User, name string) (ProjectV2, error) {
-	projects, err := getAllProjects(config, tmetricUser)
+func getProjectByName(config *config.Config, tmetricUser User, name string, client Client) (ProjectV2, error) {
+	projects, err := getAllProjects(config, tmetricUser, client)
 	if err != nil {
 		return ProjectV2{}, err
 	}


### PR DESCRIPTION
With this PR the export functionality gets more power, so that there is more flexibility in the creation of bills
1. more details of every (tmetric) report item
2. list of all (tmetric) projects selected by `-p`
3. list of all (tmetric) projects of a specific client
4. if a specific arbitrary string is not given, an empty string will be returned