### PR TITLE
get only projects that can be tracked

### DIFF
--- a/tmetric/tmetric.go
+++ b/tmetric/tmetric.go
@@ -80,6 +80,7 @@ func GetAllProjects(config *config.Config, tmetricUser User, client Client) ([]P
 	)
 	resp, err := httpClient.R().
 		SetQueryParam("ClientList", strconv.Itoa(client.Id)).
+		SetQueryParam("onlyTracked", "true").
 		SetAuthToken(config.TmetricToken).
 		Get(tmetricUrl)
 	if err != nil || resp.StatusCode() != 200 {


### PR DESCRIPTION
ruturn only projects in which user can track time.
At least for billing we should not need other projects