### PR TITLE
fix: allow new and old work package id patterns

### DIFF
--- a/cmd/tmetric.go
+++ b/cmd/tmetric.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
+	"regexp"
 	"strings"
 	"time"
 
@@ -34,8 +34,8 @@ import (
 
 func validateOpenProjectWorkPackage(input string) error {
 	if len(input) > 0 {
-		_, err := strconv.ParseInt(input, 10, 32)
-		if err != nil {
+		matched, err := regexp.MatchString(`^[a-zA-Z0-9-]+$`, input)
+		if err != nil || !matched {
 			return errors.New("Invalid WP")
 		}
 	}


### PR DESCRIPTION
Allow use of old and new work package id patterns.

old: `1234` numeric
new: `NEX-1234` alpha-numeric